### PR TITLE
解决filename中特殊符号的问题，增加鲁棒性

### DIFF
--- a/python3_main.py
+++ b/python3_main.py
@@ -61,8 +61,8 @@ for value in mm:
     #trans chinese punctuation to english
     songname = unicodedata.normalize('NFKC', songname)
     songname = songname.replace('/', "%2F").replace('\"', "%22")
-	#Replace the reserved characters in the song name. according the RFC 1738
-    songname = songname.replace('$', "%24").replace('&', "%26").replace('+', "%2B").replace(',', "%2C").replace(':', "%3A").replace(';', "%3B").replace('=',"%3D").replace('?', "%3F").replace('@', "%40")
+	#Replace the reserved characters in the song name to '-'
+    songname = songname.replace('$', "-").replace('&', "-").replace('+', "-").replace(',', "-").replace(':', "-").replace(';', "-").replace('=',"-").replace('?', "-").replace('@', "-")
 	
     
     filename = ("%s/%s/%s-%s.flac" %

--- a/python3_main.py
+++ b/python3_main.py
@@ -6,7 +6,7 @@ import urllib.request
 import urllib.error
 import os
 import sys
-
+import unicodedata
 minimumsize = 10
 print("fetching msg from %s \n" % sys.argv[1])
 url = re.sub("#/", "", sys.argv[1]).strip()
@@ -58,8 +58,12 @@ for value in mm:
 
     songname = d["data"]["songList"][0]["songName"]
     artistName = d["data"]["songList"][0]["artistName"]
-    
+    #trans chinese punctuation to english
+    songname = unicodedata.normalize('NFKC', songname)
     songname = songname.replace('/', "%2F").replace('\"', "%22")
+	#Replace the reserved characters in the song name. according the RFC 1738
+    songname = songname.replace('$', "%24").replace('&', "%26").replace('+', "%2B").replace(',', "%2C").replace(':', "%3A").replace(';', "%3B").replace('=',"%3D").replace('?', "%3F").replace('@', "%40")
+	
     
     filename = ("%s/%s/%s-%s.flac" %
                 (CURRENT_PATH, songdir, songname, artistName))


### PR DESCRIPTION
在使用过程遇到的问题：
如果文件名中出现如？这类特殊符号， 则会出现如下问题
Traceback (most recent call last):
File ".\python3_main.py", line 78, in 
with open(filename, "wb") as code:
下载会中断

修改参照，[统一资源定位符（URL）规范](http://www.blooberry.com/indexdot/html/topics/urlencoding.htm?state=urlenc&origval=%2522%3F&enc=on)  针对保留字符，对其进行编码，改成16进制形式。
同时增加了中文字符的处理，使用unicodedata包中的normalize的方法，讲中文字符转成英文字符。
本修改可避免因特殊字符导致程序中断的问题，但同时也会造成最后下载的歌曲中会出现奇怪的16进制字符，使歌曲的可读性降低。
