### PR TITLE
重写 main.py中的代码, 增加单元测试文件 test.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,9 +26,7 @@ HEADERS = {
 }
 
 
-def init():
-    if not os.path.exists(DOWNLOAD_DIR):
-        os.mkdir(DOWNLOAD_DIR)
+
 
 
 def get_args():
@@ -72,12 +70,12 @@ def fetch_song_list(url):
     contents = r.text
     song_list_name = re.search(r"<title>(.+)</title>", contents).group(1)[:-13]
 
-    logger.info("fetching Netease song list from " + song_list_name + "\n")
+    logger.info("歌单: " + song_list_name + "\n")
     pattern = r'<li><a href="/song\?id=\d+">(.+?)</a></li>'
     song_list = re.findall(pattern, contents)
     if not song_list:
         logger.error(
-            'Can not fetch information form URL. Please make sure the URL is right.\n')
+            '不能解析歌单 url\n')
         sys.exit(1)
 
     return song_list_name, song_list
@@ -97,17 +95,18 @@ def get_songid(value):
     BAIDU_SUGGESTION_API = 'http://sug.music.baidu.com/info/suggestion'
     payload = {'word': value, 'version': '2', 'from': '0'}
     value = value.replace('\\xa0', ' ')  # windows cmd 的编码问题
-    logger.info(value)
+    
 
     r = requests.get(BAIDU_SUGGESTION_API, params=payload, headers=HEADERS)
     contents = r.text
     d = json.loads(contents, encoding="utf-8")
     if not d or "errno" in d:
+        logger.info("未查找到歌曲 %s 对应的ID" % value)
         return ""
     else:
         songid = d["data"]["song"][0]["songid"]
-        logger.info("Find songid: %s" % songid)
-    return songid
+        logger.info("歌曲 %s 对应的ID为: %s" % (value, songid))
+        return songid
 
 
 def get_song_info(songid):
@@ -135,13 +134,15 @@ def get_song_info(songid):
     else:
         song_info['data'] = False
 
-    logger.info("Get song info %s" % json.dumps(song_info))
+    logger.info("获取歌曲信息 %s" % json.dumps(song_info))
     return song_info
 
 
 def download_song(song_info, mp3_option, download_folder):
     if(song_info['data']):
         if not mp3_option and song_info['size'] < 10:
+            logger.info("%s-%s 文件大小小于 10MB, 放弃下载。" %
+                        (song_info['songname'], song_info['artist']))
             return None
         else:
             filename = "{0}-{1}.flac".format(
@@ -150,23 +151,26 @@ def download_song(song_info, mp3_option, download_folder):
 
             filepath = os.path.join(download_folder, filename)
             r = requests.get(song_info['link'], headers=HEADERS, timeout=4)
-            logger.info("Downloading : %s" % filepath)
+            logger.info("下载中: %s" % filepath)
             with open(filepath, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024):
                     if chunk:
                         f.write(chunk)
 
-            logger.info("%s downloaded" % filepath)
+            logger.info("下载完成: %s " % filepath)
 
 
 def main():
     start = time.time()
 
-    init()
+    if not os.path.exists(DOWNLOAD_DIR):
+        os.mkdir(DOWNLOAD_DIR)
+
     url, mp3_option = get_args()
     if mp3_option:
         logger.info("将下载所有歌曲, 包括 MP3 格式.")
     song_list_name, song_list = fetch_song_list(url)
+    logger.info("歌单中包含的歌曲有: %s" % song_list)
 
     pool = Pool()
     song_ids = pool.map(get_songid, song_list)
@@ -176,10 +180,10 @@ def main():
     if not os.path.exists(download_folder):
         os.mkdir(download_folder)
 
-    logger.info("Start Downloading")
+    logger.info("获取歌曲信息完成，开始下载。")
     download = partial(download_song, mp3_option=mp3_option,
                        download_folder=download_folder)
-    
+
     for i in range(1, len(song_infos), 4):
         pool.map(download, song_infos[i-1:i+4-1])
         time.sleep(1)
@@ -187,9 +191,10 @@ def main():
     pool.close()
     pool.join()
     end = time.time()
-    logger.info("cost %s s", str(end - start))
+    logger.info("共耗时 %s s", str(end - start))
 
 
+# 禁止 requests 模组使用系统代理
 os.environ['no_proxy'] = '*'
 logger = set_logger()
 

--- a/main.py
+++ b/main.py
@@ -13,26 +13,38 @@ import sys
 import unicodedata
 import time
 from multiprocessing.dummy import Pool
+from functools import partial
 
 MINIMUM_SIZE = 10
-DOWNLOAD_DIR = "songs_dir"
+DOWNLOAD_DIR = os.path.join(os.getcwd(), "songs_dir")
 CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
 LOG_LEVEL = logging.INFO
 LOG_FILE = 'download.log' or False
 LOG_FORMAT = '%(asctime)s %(filename)s:%(lineno)d [%(levelname)s] %(message)s'
+HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36'
+}
+
+
+def init():
+    if not os.path.exists(DOWNLOAD_DIR):
+        os.mkdir(DOWNLOAD_DIR)
+
 
 def get_args():
-  parser = argparse.ArgumentParser(
-    usage = "python main.py 歌单地址",
-    description="根据网易云音乐歌单, 下载对应无损FLAC歌曲到本地."
+    parser = argparse.ArgumentParser(
+        usage="python main.py 歌单地址",
+        description="根据网易云音乐歌单, 下载对应无损FLAC歌曲到本地."
     )
-  parser.add_argument('playlist_url', type=str, help="网易云音乐歌单url")
-  parser.add_argument('-m', '--mp3', action="store_false", dest='mp3_option', help="下载mp3资源")
-  parse_result = parser.parse_args()
-  url = parse_result.playlist_url
-  mp3_option = parse_result.mp3_option
+    parser.add_argument('playlist_url', type=str, help="网易云音乐歌单url")
+    parser.add_argument('-m', '--mp3', action="store_true",
+                        dest='mp3_option', help="下载mp3资源")
+    parse_result = parser.parse_args()
+    url = parse_result.playlist_url
+    mp3_option = parse_result.mp3_option
 
-  return url, mp3_option
+    return url, mp3_option
+
 
 def set_logger():
     logger = logging.getLogger()
@@ -52,21 +64,24 @@ def set_logger():
 
     return logger
 
-logger = set_logger()
 
 def fetch_song_list(url):
-    logger.info("fetching Netease song list from " + url + "\n")
-    url = url.replace("/#", "").strip()
-    r = requests.get(url, headers={
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36'})
+    _id = re.search(r'id=(\d+)', url).group(1)
+    url = "http://music.163.com/playlist?id={0}".format(_id)
+    r = requests.get(url, headers=HEADERS)
     contents = r.text
-    pattern = r'<li><a href="/song\?id=\d+">(.+?)</a></li>'
-    song_names = re.findall(pattern, contents)
-    if not song_names:
-        logger.error('Can not fetch information form URL. Please make sure the URL is right.\n')
-        os._exit(0)
+    song_list_name = re.search(r"<title>(.+)</title>", contents).group(1)[:-13]
 
-    return song_names
+    logger.info("fetching Netease song list from " + song_list_name + "\n")
+    pattern = r'<li><a href="/song\?id=\d+">(.+?)</a></li>'
+    song_list = re.findall(pattern, contents)
+    if not song_list:
+        logger.error(
+            'Can not fetch information form URL. Please make sure the URL is right.\n')
+        sys.exit(1)
+
+    return song_list_name, song_list
+
 
 def validate_file_name(songname):
     # trans chinese punctuation to english
@@ -77,96 +92,106 @@ def validate_file_name(songname):
     rstr = r"[\/\\\:\*\?\"\<\>\|\+\-:;=?@]"  # '/ \ : * ? " < > |'
     return re.sub(rstr, "_", songname)
 
-def get_songid(value):
-   BAIDU_SUGGESTION_API = 'http://sug.music.baidu.com/info/suggestion'
-   payload = {'word': value, 'version': '2', 'from': '0'}
-   value = value.replace('\\xa0', ' ')  # windows cmd 的编码问题
-   logger.info(value)
 
-   r = requests.get(BAIDU_SUGGESTION_API, params=payload)
-   contents = r.text
-   d = json.loads(contents, encoding="utf-8")
-   if d is not None and 'data' not in d:
-       return ""
-   else:
-       songid = d["data"]["song"][0]["songid"]
-       logger.info("find songid: %s" % songid)
-       return songid
+def get_songid(value):
+    BAIDU_SUGGESTION_API = 'http://sug.music.baidu.com/info/suggestion'
+    payload = {'word': value, 'version': '2', 'from': '0'}
+    value = value.replace('\\xa0', ' ')  # windows cmd 的编码问题
+    logger.info(value)
+
+    r = requests.get(BAIDU_SUGGESTION_API, params=payload, headers=HEADERS)
+    contents = r.text
+    d = json.loads(contents, encoding="utf-8")
+    if not d or "errno" in d:
+        return ""
+    else:
+        songid = d["data"]["song"][0]["songid"]
+        logger.info("Find songid: %s" % songid)
+    return songid
+
 
 def get_song_info(songid):
     BAIDU_MUSIC_API = "http://music.baidu.com/data/music/fmlink"
     payload = {'songIds': songid, 'type': 'flac'}
-    r = requests.get(BAIDU_MUSIC_API, params=payload)
-    contents = r.text
-    return json.loads(contents, encoding="utf-8")
+    r = requests.get(BAIDU_MUSIC_API, params=payload, headers=HEADERS)
+    contents = json.loads(r.text)
+    song_info = {}
+    if(contents['errorCode'] == 22000):
+        song_info['songname'] = contents['data']['songList'][0]['songName']
+        song_info['artist'] = contents['data']['songList'][0]['artistName']
 
-def download_song(d, songlink, is_skip_mp3_songs):
-   songname = d["data"]["songList"][0]["songName"]
-   songname = validate_file_name(songname)
-   artistName = d["data"]["songList"][0]["artistName"]
-   artistName = validate_file_name(artistName)
+        link = contents['data']['songList'][0]['songLink']
+        song_info['link'] = link or None
+        size = contents['data']['songList'][0]['size']
+        if(size):
+            song_info['size'] = round(int(size) / (1024 ** 2))
+        else:
+            song_info['size'] = None
 
-   filename = ("%s/%s/%s-%s.flac" %
-               (CURRENT_PATH, DOWNLOAD_DIR, songname, artistName))
+        if(song_info['link'] and song_info['size']):
+            song_info['data'] = True
+        else:
+            song_info['data'] = False
+    else:
+        song_info['data'] = False
 
-   f = urllib.request.urlopen(songlink, timeout=10)
-   headers = requests.head(songlink).headers
-   if 'Content-Length' in headers:
-       size = round(int(headers['Content-Length']) / (1024 ** 2), 2)
-   else:
-       return
+    logger.info("Get song info %s" % json.dumps(song_info))
+    return song_info
 
-   # Download unfinished Flacs again.
-   # Delete useless flacs
-   if not os.path.isfile(filename) or (is_skip_mp3_songs and os.path.getsize(filename) < MINIMUM_SIZE):
-       logger.info("%s is downloading now ......\n\n" % songname)
-       if (not is_skip_mp3_songs) or size >= MINIMUM_SIZE:
-           with open(filename, "wb") as code:
-               code.write(f.read())
-           logger.info("%s finished downloading ......\n\n" % songname)
-       else:
-           logger.warning("the size of %s (%r Mb) is less than 10 Mb, skipping" %
-                 (filename, size))
-   else:
-       logger.info("%s is already downloaded. Finding next song...\n\n" % songname)
+
+def download_song(song_info, mp3_option, download_folder):
+    if(song_info['data']):
+        if not mp3_option and song_info['size'] < 10:
+            return None
+        else:
+            filename = "{0}-{1}.flac".format(
+                validate_file_name(song_info['songname']),
+                validate_file_name(song_info['artist']))
+
+            filepath = os.path.join(download_folder, filename)
+            r = requests.get(song_info['link'], headers=HEADERS, timeout=4)
+            logger.info("Downloading : %s" % filepath)
+            with open(filepath, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=1024):
+                    if chunk:
+                        f.write(chunk)
+
+            logger.info("%s downloaded" % filepath)
+
 
 def main():
-    url, is_skip_mp3_songs = get_args()
-    if not is_skip_mp3_songs:
-      logger.info("将下载所有歌曲, 包括 MP3 格式.")
-    song_names = fetch_song_list(url)
-    p = Pool()
-    for value in song_names:
-        songid = get_songid(value)
-        if songid == "":
-            logger.info("can not find %s 's songid %s'. Finding next song...\n\n" % (value, songid))
-            continue
-
-        d = get_song_info(songid)
-        if ('data' not in d) or d['data'] == '' or d['data']['songList'] == '':
-            continue
-
-        songlink = d["data"]["songList"][0]["songLink"]
-        logger.info("find songlink: ")
-        if (len(songlink) < 10):
-            logger.warning("\tdo not have flac\n")
-            continue
-        logger.info(songlink)
-
-        if not os.path.exists(DOWNLOAD_DIR):
-            os.makedirs(DOWNLOAD_DIR)
-        # download_song(d, songlink)
-        p.apply_async(download_song, args=(d, songlink, is_skip_mp3_songs))
-    logger.info("\n================================================================\n")
-    logger.info('Waiting for all download subprocesses done...')
-    p.close()
-    p.join()
-
-    logger.info("\n================================================================\n")
-    logger.info("Download finish!\nSongs' directory is %s/songs_dir" % os.getcwd())
-
-if __name__ == "__main__":
     start = time.time()
-    main()
+
+    init()
+    url, mp3_option = get_args()
+    if mp3_option:
+        logger.info("将下载所有歌曲, 包括 MP3 格式.")
+    song_list_name, song_list = fetch_song_list(url)
+
+    pool = Pool()
+    song_ids = pool.map(get_songid, song_list)
+    song_infos = pool.map(get_song_info, song_ids)
+
+    download_folder = os.path.join(DOWNLOAD_DIR, song_list_name)
+    if not os.path.exists(download_folder):
+        os.mkdir(download_folder)
+
+    logger.info("Start Downloading")
+    download = partial(download_song, mp3_option=mp3_option,
+                       download_folder=download_folder)
+    
+    for i in range(1, len(song_infos), 4):
+        pool.map(download, song_infos[i-1:i+4-1])
+        time.sleep(1)
+
+    pool.close()
+    pool.join()
     end = time.time()
     logger.info("cost %s s", str(end - start))
+
+
+os.environ['no_proxy'] = '*'
+logger = set_logger()
+
+if __name__ == "__main__":
+    main()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,112 @@
+import shutil, tempfile
+import logging
+import unittest
+import json
+import re
+import os
+import time
+from main import set_logger, fetch_song_list, get_songid, get_song_info, download_song
+from main import MINIMUM_SIZE
+
+
+class Test(unittest.TestCase):
+
+    # def setUp(self):
+    #     self.test_dir = tempfile.mkdtemp()  
+    #     print(self.test_dir)
+    # def tearDown(self):
+    #     shutil.rmtree(self.test_dir)
+    def test_fetch_song_list(self):
+        correct_url = "https://music.163.com/#/playlist?id=2594603185"
+        correct_url_songlist = [
+            'Careless Whisper',
+            'Be Free',
+            'How Long Will I Love You',
+            'Wham Bam Shang-A-Lang',
+            'California Dreaming (重庆森林)',
+            'Talk Baby Talk',
+            '水边的阿狄丽娜',
+            'Levels',
+            'Ode an die Freude',
+            'Let Me Know'
+            ]
+        wrong_url = "id=22"
+
+        self.assertEqual(len(fetch_song_list(correct_url)[1]) , 10)
+        self.assertCountEqual(fetch_song_list(correct_url)[1], correct_url_songlist)
+        with self.assertRaises(SystemExit) as cm:
+            fetch_song_list(wrong_url)
+        self.assertEqual(cm.exception.code, 1)
+    def test_get_songid(self):
+        correct_name = "Let Me Know"
+        _id = '2043287'
+
+        wrong_name = "youmeiyouzheyangyishouge"
+        
+        
+        self.assertEqual(get_songid(correct_name), _id)
+        self.assertEqual(get_songid(wrong_name), "")
+
+    def test_get_song_info(self):
+        correct_id = '296532523'
+        correct_song_info = {
+            'songname': "Careless Whisper",
+            'artist': "Sharon Cuneta,Andrew Ridgeley,George Michael",
+            'link': "http://zhangmenshiting.qianqian.com/data2/music/14a5cc3a8be3f13184e155c69e59d4b7/594663375/\\d+.flac\\?xcode=.+",
+            'size': 39,
+            'data': True
+        }
+
+        wrong_id = ['2', '2233']
+        wrong_song_info = {
+            'data': False
+        }
+        song_info = get_song_info(correct_id)
+        self.assertRegex(song_info['link'], correct_song_info['link'])
+
+        del song_info['link']
+        del correct_song_info['link']
+
+        self.assertEqual(song_info, correct_song_info)
+        for _id in wrong_id:
+            self.assertEqual(get_song_info(_id), wrong_song_info)
+
+    # def test_download_song(self):
+    #     songlist = fetch_song_list('https://music.163.com/#/playlist?id=2616291276')
+    #     song_ids = map(get_songid, songlist)
+    #     data = list(map(get_song_info, song_ids))
+
+    #     count_flac = 0
+    #     for i in range(len(data)):
+    #         if data[i]['size'] >= MINIMUM_SIZE:
+    #             count_flac += 1
+
+    #     def lam(mp3_option):
+    #         for n in data:
+    #             download_song(n, mp3_option, self.test_dir)
+    #             time.sleep(1)
+ 
+    #         count = 0
+
+    #         files = os.listdir(self.test_dir)
+    #         if not mp3_option:
+    #             for file in files:
+    #                 file_size = os.path.getsize(os.path.join(self.test_dir, file))/(1024 ** 2)
+    #                 print("filesize:{}".format(file_size))
+    #                 if file_size >= MINIMUM_SIZE:
+    #                     count += 1
+    #             self.assertEqual(count, count_flac)
+    #         else:
+    #             self.assertEqual(len(files), len(data))
+
+    #     lam(False)
+    #     shutil.rmtree(self.test_dir)
+    #     self.test_dir = tempfile.mkdtemp()
+    #     lam(True)
+        
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
`fetch_song_list()` 函数可以接受 **我的音乐** 中的歌单 url 地址了， 如果登录了网易云账户， 那么可以直接复制我的音乐中的歌单。
`fetch_song_list()` 函数会返回歌单名字和歌单内歌曲的名字。
`get_song_info()` 函数会提取访问 api 得到的有用信息，返回一个 dict 供下载函数使用。
使用 `pool.map()` 函数替代 `pool.apply_async()` 函数， 每下载 4 首歌曲就暂停程序 1s，避免被远程计算机积极拒绝。#46
总的下载文件夹为 `songs_dir`, 每个歌单的下载文件夹为 `songs_dir//歌单名字`，这样如果下载了好几个歌单，歌曲不会混杂在一起。
添加` os.environ['no_proxy'] = '*' ` 语句禁止 requests 库使用系统代理，以免科学上网时使用这个脚本频繁报错。
添加单元测试 test.py ，目前只有对三个函数的测试

这次重写主要是想让下载部分的代码逻辑清楚一点，不知道有没有做到，需要你看下代码  @YongHaoWu 